### PR TITLE
Use correct key value for passing in path to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const { run } = require("oxipng-node");
 async function optimizeCat() {
   try {
     await run({
-      input: "/Users/user/project/images/cat.png",
+      path: "/Users/user/project/images/cat.png",
       out: "/Users/user/project/images/optimized/cat.png",
       optimization: 2,
     });


### PR DESCRIPTION
The key value for passing in the path to the file, which should be optimized, is wrong in the example. Instead of `input`, the path to the string, which should be optimized, needs to be assigned to the `path` key.